### PR TITLE
Enable a plugin to provide `main_template_vars.php` and page-specific content

### DIFF
--- a/includes/classes/DbRepositories/PluginControlRepository.php
+++ b/includes/classes/DbRepositories/PluginControlRepository.php
@@ -93,6 +93,7 @@ class PluginControlRepository
                 ") ON DUPLICATE KEY UPDATE " .
                 "name = VALUES(name), " .
                 "description = VALUES(description), " .
+                "type = VALUES(type), " .
                 "infs = VALUES(infs), " .
                 "author = VALUES(author), " .
                 "zc_contrib_id = VALUES(zc_contrib_id)"

--- a/includes/classes/PluginManager.php
+++ b/includes/classes/PluginManager.php
@@ -271,15 +271,16 @@ class PluginManager
                     'unique_key' => $uniqueKey,
                     'name' => $plugin[$pluginVersion]['pluginName'],
                     'description' => $plugin[$pluginVersion]['pluginDescription'],
-                    'type' => '',
+                    'type' => isset($plugin[$pluginVersion]['template']) ? 'template' : '',
                     'status' => PluginStatus::NOT_INSTALLED,
                     'author' => $plugin[$pluginVersion]['pluginAuthor'],
                     'version' => '',
                     'zc_versions' => '',
                     'infs' => 1,
-                    'zc_contrib_id' => $plugin[$pluginVersion]['pluginId'],
+                    'zc_contrib_id' => (int)$plugin[$pluginVersion]['pluginId'],
                 ];
         }
+
         // Insert new, and update existing, plugins
         $this->pluginControl->upsertMany($insertValues);
         $this->pluginControlVersion->upsertMany($versionInsertValues);

--- a/includes/classes/ResourceLoaders/BaseLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/BaseLanguageLoader.php
@@ -134,12 +134,16 @@ class BaseLanguageLoader
     /**
      * @since ZC v2.2.1
      */
-    protected function getTemplateFirstLanguageFiles(string $rootPath, string $fileName): array
+    protected function getTemplateFirstLanguageFiles(string $languageDir, string $fileName): array
     {
-        $rootPath = rtrim($rootPath, '/') . '/';
+        $languageDir = rtrim($languageDir, '/') . '/';
         $files = [];
         foreach ($this->getTemplateInheritanceChainForLookup(true) as $templateKey) {
-            $path = $rootPath . $templateKey . '/' . $fileName;
+            $path = $this->templateResolver->getTemplateBasePath($templateKey) . $languageDir;
+            if ($templateKey !== 'template_default') {
+                $path .= $templateKey . '/';
+            }
+            $path .= $fileName;
             if (is_file($path)) {
                 $files[] = $path;
             }
@@ -178,12 +182,19 @@ class BaseLanguageLoader
     {
         $roots = [];
         $templateRecord = $this->templateResolver->getTemplateRecord($templateKey);
-        if (!empty($templateRecord['is_plugin_template']) && !empty($templateRecord['plugin_key']) && !empty($templateRecord['plugin_version'])) {
+
+        // -----
+        // If the specified template is a plugin and it's active, make sure it's at
+        // the top of the template's "roots" directories.
+        //
+        // @TODO: Rework will be needed for the 'child' template implementation.
+        //
+        if ($this->templateResolver->isPluginTemplate($templateKey) && $this->templateResolver->isActiveTemplate($templateKey)) {
             $roots[] = $this->zcPluginsDir . $templateRecord['plugin_key'] . '/' . $templateRecord['plugin_version'] . '/catalog/includes/languages/';
         }
 
         foreach ($this->pluginList as $plugin) {
-            if (empty($plugin['unique_key']) || empty($plugin['version'])) {
+            if (empty($plugin['unique_key']) || empty($plugin['version']) || $plugin['type'] === 'template') {
                 continue;
             }
             $roots[] = $this->zcPluginsDir . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/languages/';

--- a/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
+++ b/includes/classes/ResourceLoaders/CatalogArraysLanguageLoader.php
@@ -218,9 +218,14 @@ class CatalogArraysLanguageLoader extends ArraysLanguageLoader
         //
         $defineListTemplate = [];
         foreach ($this->getTemplateInheritanceChainForLookup(true) as $templateKey) {
+            if ($templateKey === 'template_default') {
+                continue;
+            }
+
+            $languageMainDir = $this->templateResolver->getTemplateBasePath($templateKey) . DIR_WS_LANGUAGES;
             $defineListTemplate = array_merge(
                 $defineListTemplate,
-                $this->loadArraysFromDirectory(DIR_WS_LANGUAGES, $_SESSION['language'], '/extra_definitions/' . $templateKey)
+                $this->loadArraysFromDirectory($languageMainDir, $_SESSION['language'], '/extra_definitions/' . $templateKey)
             );
         }
 

--- a/includes/classes/ResourceLoaders/PageLoader.php
+++ b/includes/classes/ResourceLoaders/PageLoader.php
@@ -173,8 +173,17 @@ class PageLoader
      */
     public function getBodyCode(): string
     {
-        if (file_exists(DIR_WS_MODULES . 'pages/' . $this->mainPage . '/main_template_vars.php')) {
-            return DIR_WS_MODULES . 'pages/' . $this->mainPage . '/main_template_vars.php';
+        // -----
+        // Determine where, if anywhere, the current-page's main_template_vars.php
+        // file resides.
+        //
+        // listModulePagesFiles returns all locations and the first-found file is used. That'll
+        // be the file in /includes/modules/pages/{current_page} or (searching all active
+        // plugins alphanumerically) the first-found in any zc_plugins.
+        //
+        $template_vars_locations = $this->listModulePagesFiles('main_template_vars');
+        if (count($template_vars_locations) !== 0) {
+            return $template_vars_locations[0];
         }
         return $this->getTemplateDirectory('tpl_' . preg_replace('/.php/', '', $this->mainPage) . '_default.php', DIR_WS_TEMPLATE, $this->mainPage, 'templates') . '/tpl_' . $this->mainPage . '_default.php';
     }

--- a/includes/classes/ResourceLoaders/PageLoader.php
+++ b/includes/classes/ResourceLoaders/PageLoader.php
@@ -22,6 +22,7 @@ class PageLoader
     private string $mainPage;
     private FileSystem $fileSystem;
     private ?TemplateResolver $templateResolver = null;
+    private array $templateSearchDirectories = [];
 
     /**
      * @since ZC v1.5.8
@@ -118,14 +119,16 @@ class PageLoader
     }
 
     /**
+     * Note: Changed from public to private for ZC 3.0.0.
+     *
      * @since ZC v1.5.7
      */
-    public function getTemplatePartFromDirectory(array $directoryArray, string $pageDirectory, string $templatePart, string $fileExtension): array
+    private function getTemplatePartFromDirectory(array $directoryArray, string $pageDirectory, string $templatePart, string $fileExtension): array
     {
         if ($dir = @dir($pageDirectory)) {
             while ($file = $dir->read()) {
                 if (!is_dir($pageDirectory . $file)) {
-                    if (substr($file, strrpos($file, '.')) === $fileExtension && preg_match($templatePart, $file)) {
+                    if (str_ends_with($file, $fileExtension) && preg_match($templatePart, $file)) {
                         $directoryArray[] = $file;
                     }
                 }
@@ -136,17 +139,36 @@ class PageLoader
     }
 
     /**
+     * Locates a specified file ($templateCode) within a specified directory ($currentTemplate), which
+     * is normally specified as TEMPLATE_DEFAULT).
+     *
+     * File location search order; first found is returned:
+     *
+     * 1. $currentTemplate / $currentPage
+     * 2. zc_plugins default / $currentPage (first-found, alphanumerically sorted)
+     * 3. template_default / $currentPage
+     * 4. $currentTemplate / $templateDir
+     * 5. zc_plugins default / $templateDir (first-found, alphanumerically sorted)
+     * 6. template_default / $templateDir
+     *
+     * For example, assuming that the selected template is 'responsive_classic':
+     *
+     * - getTemplateDirectory('tpl_main_page.php', DIR_WS_TEMPLATE, 'contact_us', 'common') returns
+     *   - DIR_WS_TEMPLATE . 'common'
+     * - getTemplateDirectory('tpl_main_page.php', DIR_WS_TEMPLATE, 'popup_shipping_estimator', 'common') returns
+     *   - DIR_WS_TEMPLATES . 'template_default/popup_shipping_estimator'
+     *
      * @since ZC v1.5.8
      */
-    function getTemplateDirectory(string $templateCode, string $currentTemplate, string $currentPage, string $templateDir): string
+    public function getTemplateDirectory(string $templateCode, string $currentTemplate, string $currentPage, string $templateDir): string
     {
-        $templateCode = preg_replace('/\//', '', $templateCode);
+        $templateCode = str_replace("/", '', $templateCode);
         foreach ($this->getTemplateSearchDirectories($this->getCurrentTemplateKey($currentTemplate), $currentPage, $templateDir) as $directory) {
             if ($this->fileSystem->fileExistsInDirectory($directory, $templateCode)) {
                 return rtrim($directory, '/');
             }
         }
-        return rtrim(DIR_WS_TEMPLATES . 'template_default/' . $templateDir, '/');
+        return DIR_WS_TEMPLATES . 'template_default/' . trim($templateDir, '/');
     }
 
     /**
@@ -189,28 +211,59 @@ class PageLoader
     }
 
     /**
+     * Returns an array with potential template-related directories to
+     * be searched for a file.
+     *
+     * File locations' returned in this array/precedence order:
+     *
+     * 1. $templateKey directory / $currentPage
+     * 2. zc_plugins default / $currentPage (alphanumerically sorted)
+     * 3. template_default / $currentPage
+     * 4. $templateKey directory / $templateDir
+     * 5. zc_plugins default / $templateDir (alphanumerically sorted)
+     * 6. template_default / $templateDir
+     *
      * @since ZC v3.0.0
      */
     private function getTemplateSearchDirectories(string $templateKey, string $currentPage, string $templateDir): array
     {
+        // -----
+        // If there was a previous request for the same information, return the
+        // cached array.
+        //
+        if (isset($this->templateSearchDirectories[$templateKey][$currentPage][$templateDir])) {
+            return $this->templateSearchDirectories[$templateKey][$currentPage][$templateDir];
+        }
+
         $directories = [];
         $inheritanceChain = $this->getNonDefaultInheritanceChain($templateKey);
 
         foreach ($inheritanceChain as $chainTemplateKey) {
             $directories = array_merge(
                 $directories,
-                $this->getCoreTemplateDirectories($chainTemplateKey, $currentPage, $templateDir),
-                $this->getOverlayDirectoriesForTarget($chainTemplateKey, $templateDir)
+                $this->getTemplateSubDirectory($chainTemplateKey, $currentPage)
             );
         }
-
         $directories = array_merge(
             $directories,
-            $this->getOverlayDirectoriesForTarget('default', $templateDir),
-            $this->getCoreTemplateDirectories('template_default', $currentPage, $templateDir)
+            $this->getDefaultTemplateSubDirectories($currentPage)
         );
 
-        return array_values(array_unique(array_filter($directories)));
+        foreach ($inheritanceChain as $chainTemplateKey) {
+            $directories = array_merge(
+                $directories,
+                $this->getTemplateSubDirectory($chainTemplateKey, $templateDir)
+            );
+        }
+        $directories = array_merge(
+            $directories,
+            $this->getDefaultTemplateSubDirectories($templateDir)
+        );
+
+        $directories = array_values(array_unique(array_filter($directories)));
+        $this->templateSearchDirectories[$templateKey][$currentPage][$templateDir] = $directories;
+
+        return $directories;
     }
 
     /**
@@ -231,7 +284,7 @@ class PageLoader
     /**
      * @since ZC v3.0.0
      */
-    private function getCoreTemplateDirectories(string $templateKey, string $currentPage, string $templateDir): array
+    private function getTemplateSubDirectory(string $templateKey, string $subDirectory): array
     {
         $record = $this->getTemplateResolver()->getTemplateRecord($templateKey);
         if ($record === null) {
@@ -244,22 +297,27 @@ class PageLoader
         }
 
         return [
-            $templateRoot . '/' . trim($currentPage, '/') . '/',
-            $templateRoot . '/' . trim($templateDir, '/') . '/',
+            $templateRoot . '/' . trim($subDirectory, '/') . '/',
         ];
     }
 
     /**
      * @since ZC v3.0.0
      */
-    private function getOverlayDirectoriesForTarget(string $targetTemplate, string $templateDir): array
+    private function getDefaultTemplateSubDirectories(string $subDirectory): array
     {
         $directories = [];
         foreach ($this->installedPlugins as $plugin) {
-            foreach ($this->getPluginOverlayDirectories($plugin, $templateDir, [$targetTemplate]) as $directory) {
+            foreach ($this->getPluginOverlayDirectories($plugin, $subDirectory) as $directory) {
                 $directories[] = $directory;
             }
         }
+
+        $default_dir = DIR_WS_TEMPLATES . 'template_default/' . trim($subDirectory, '/') . '/';
+        if (is_dir($default_dir)) {
+            $directories[] = $default_dir;
+        }
+
         return $directories;
     }
 

--- a/includes/classes/ResourceLoaders/PageLoader.php
+++ b/includes/classes/ResourceLoaders/PageLoader.php
@@ -34,12 +34,11 @@ class PageLoader
         $this->fileSystem = $fileSystem;
     }
 
-    // -----
-    // This method locates the 'base' module-page directory, either in the
-    // storefront's /includes/modules/pages or in an encapsulated plugin's
-    // /catalog/includes/modules/pages directory.
-    //
     /**
+     * This method locates the 'base' module-page directory, either in the
+     * storefront's /includes/modules/pages or in an encapsulated plugin's
+     * /catalog/includes/modules/pages directory.
+     *
      * @since ZC v1.5.7
      */
     public function findModulePageDirectory(string $context = 'catalog'): bool|string
@@ -326,7 +325,7 @@ class PageLoader
      */
     private function getPluginOverlayDirectories(array $plugin, string $templateDir, ?array $targets = null): array
     {
-        $templatesRoot = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/templates/';
+        $templatesRoot = 'zc_plugins/' . $plugin['unique_key'] . '/' . $plugin['version'] . '/catalog/includes/templates/default/';
         if (!is_dir(DIR_FS_CATALOG . $templatesRoot)) {
             return [];
         }

--- a/includes/classes/ResourceLoaders/TemplateResolver.php
+++ b/includes/classes/ResourceLoaders/TemplateResolver.php
@@ -157,6 +157,30 @@ class TemplateResolver
     /**
      * @since ZC v3.0.0
      */
+    public function isActiveTemplate(string $templateKey): bool
+    {
+        $record = $this->getTemplateRecord($templateKey);
+        if ($record === null) {
+            return false;
+        }
+        return !empty($record['is_active']);
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
+    public function getTemplateBasePath(string $templateKey): string
+    {
+        $record = $this->getTemplateRecord($templateKey);
+        if ($record === null) {
+            return '';
+        }
+        return $record['template_base_fs'];
+    }
+
+    /**
+     * @since ZC v3.0.0
+     */
     private function getTemplateRecords(): array
     {
         $templateDto = TemplateDto::getInstance();
@@ -198,6 +222,7 @@ class TemplateResolver
             }
 
             $templates[$templateKey] = array_merge($templateInfo, [
+                'template_base_fs' => $this->normalizeDirectory(DIR_FS_CATALOG) . '/',
                 'template_key' => $templateKey,
                 'template_path' => $templatePath . '/',
                 'template_catalog_path' => 'includes/templates/' . $templateKey . '/',
@@ -280,6 +305,7 @@ class TemplateResolver
             : $templatePath . 'template_settings.php';
 
         return array_merge($templateInfo, [
+            'template_base_fs' => $this->normalizeDirectory($versionPath . '/catalog/') . '/',
             'template_key' => $templateKey,
             'template_path' => $templatePath,
             'template_catalog_path' => $templateCatalogPath,

--- a/not_for_release/testFramework/Support/zcTemplateResolverTest.php
+++ b/not_for_release/testFramework/Support/zcTemplateResolverTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @copyright Copyright 2003-2020 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ */
+
+namespace Tests\Support;
+
+use Tests\Support\zcUnitTestCase;
+
+/**
+ * Class zcTemplateResolverTest
+ */
+abstract class zcTemplateResolverTest extends zcUnitTestCase
+{
+
+    /**
+     * @param $qfrResult
+     */
+    public function instantiateQfr($qfrResult)
+    {
+        $qfr = $this->getMockBuilder('queryFactoryResult')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $qfr->fields = $qfrResult;
+        $qfr->method('RecordCount')->willReturn(1);
+
+        $GLOBALS['db'] = $this->getMockBuilder('queryFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $GLOBALS['db']->method('execute')->willReturn($qfr);
+    }
+
+}

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/BaseLanguageLoaderTemplateChainTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/BaseLanguageLoaderTemplateChainTest.php
@@ -6,10 +6,10 @@
 
 namespace Tests\Unit\testsTemplateResolver;
 
-use Tests\Support\zcUnitTestCase;
+use Tests\Support\zcTemplateResolverTest;
 use Zencart\LanguageLoader\BaseLanguageLoader;
 
-class BaseLanguageLoaderTemplateChainTest extends zcUnitTestCase
+class BaseLanguageLoaderTemplateChainTest extends zcTemplateResolverTest
 {
     private string $fixtureRoot;
 
@@ -17,7 +17,9 @@ class BaseLanguageLoaderTemplateChainTest extends zcUnitTestCase
     {
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateSelect.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         require_once DIR_FS_CATALOG . 'includes/classes/FileSystem.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/BaseLanguageLoader.php';
 
@@ -54,6 +56,13 @@ PHP
         file_put_contents($this->fixtureRoot . '/zc_plugins/ChildTheme/v1.0.0/catalog/includes/languages/english/child_theme/lang.example.php', "<?php\nreturn ['A' => 'plugin child'];\n");
         file_put_contents($this->fixtureRoot . '/includes/languages/template_default/lang.english.php', "<?php\nreturn ['A' => 'default main'];\n");
         file_put_contents($this->fixtureRoot . '/includes/languages/responsive_classic/lang.english.php', "<?php\nreturn ['A' => 'base main'];\n");
+
+        $this->instantiateQfr([
+            'template_id' => '1',
+            'template_dir' => 'child_theme',
+            'template_language' => 0,
+            'template_settings' => null,
+        ]);
     }
 
     public function tearDown(): void

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/BaseLanguageLoaderTemplateChainTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/BaseLanguageLoaderTemplateChainTest.php
@@ -16,6 +16,7 @@ class BaseLanguageLoaderTemplateChainTest extends zcUnitTestCase
     public function setUp(): void
     {
         parent::setUp();
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
         require_once DIR_FS_CATALOG . 'includes/classes/FileSystem.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/BaseLanguageLoader.php';

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/FunctionsFilesTemplateResolutionTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/FunctionsFilesTemplateResolutionTest.php
@@ -4,9 +4,9 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
-use Tests\Support\zcUnitTestCase;
+use Tests\Support\zcTemplateResolverTest;
 
-class FunctionsFilesTemplateResolutionTest extends zcUnitTestCase
+class FunctionsFilesTemplateResolutionTest extends zcTemplateResolverTest
 {
     private const CHILD_THEME_PLUGIN = 'UnitTestFunctionsChildTheme';
     private const CHILD_TEMPLATE_KEY = 'functions_child_theme';
@@ -22,7 +22,9 @@ class FunctionsFilesTemplateResolutionTest extends zcUnitTestCase
     {
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateSelect.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         require_once DIR_FS_CATALOG . 'includes/functions/functions_templates.php';
         require_once DIR_FS_CATALOG . 'includes/functions/functions_files.php';
 
@@ -85,6 +87,13 @@ PHP
                 'version' => 'v1.0.0',
             ],
         ];
+
+        $this->instantiateQfr([
+            'template_id' => '1',
+            'template_dir' => self::CHILD_TEMPLATE_KEY,
+            'template_language' => 0,
+            'template_settings' => null,
+        ]);
     }
 
     public function tearDown(): void

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/FunctionsFilesTemplateResolutionTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/FunctionsFilesTemplateResolutionTest.php
@@ -21,6 +21,7 @@ class FunctionsFilesTemplateResolutionTest extends zcUnitTestCase
     public function setUp(): void
     {
         parent::setUp();
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
         require_once DIR_FS_CATALOG . 'includes/functions/functions_templates.php';
         require_once DIR_FS_CATALOG . 'includes/functions/functions_files.php';

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/FunctionsTemplatesTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/FunctionsTemplatesTest.php
@@ -4,9 +4,9 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
-use Tests\Support\zcUnitTestCase;
+use Tests\Support\zcTemplateResolverTest;
 
-class FunctionsTemplatesTest extends zcUnitTestCase
+class FunctionsTemplatesTest extends zcTemplateResolverTest
 {
     private string $fixtureRoot;
 
@@ -14,7 +14,9 @@ class FunctionsTemplatesTest extends zcUnitTestCase
     {
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateSelect.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         require_once DIR_FS_CATALOG . 'includes/functions/functions_templates.php';
 
         $this->fixtureRoot = sys_get_temp_dir() . '/zencart-functions-templates-' . uniqid('', true);
@@ -49,6 +51,13 @@ return [
 ];
 PHP
         );
+
+        $this->instantiateQfr([
+            'template_id' => '1',
+            'template_dir' => 'child_theme',
+            'template_language' => 0,
+            'template_settings' => null,
+        ]);
     }
 
     public function tearDown(): void

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/HtmlOutputTemplateAssetFallbackTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/HtmlOutputTemplateAssetFallbackTest.php
@@ -4,9 +4,9 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
-use Tests\Support\zcUnitTestCase;
+use Tests\Support\zcTemplateResolverTest;
 
-class HtmlOutputTemplateAssetFallbackTest extends zcUnitTestCase
+class HtmlOutputTemplateAssetFallbackTest extends zcTemplateResolverTest
 {
     private const BASE_THEME_PLUGIN = 'UnitTestHtmlOutputBaseTheme';
     private const CHILD_THEME_PLUGIN = 'UnitTestHtmlOutputChildTheme';
@@ -23,7 +23,9 @@ class HtmlOutputTemplateAssetFallbackTest extends zcUnitTestCase
     {
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateSelect.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         require_once DIR_FS_CATALOG . 'includes/functions/html_output.php';
 
         $this->baseThemePluginRoot = DIR_FS_CATALOG . 'zc_plugins/' . self::BASE_THEME_PLUGIN . '/v1.0.0/';
@@ -102,6 +104,13 @@ PHP
         file_put_contents($this->baseImage, 'base');
         file_put_contents($this->baseThemePluginImage, 'base-plugin');
         file_put_contents($this->templateDogfoodLanguageImage, 'lang');
+
+        $this->instantiateQfr([
+            'template_id' => '1',
+            'template_dir' => self::CHILD_TEMPLATE_KEY,
+            'template_language' => 0,
+            'template_settings' => null,
+        ]);
     }
 
     public function tearDown(): void

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/HtmlOutputTemplateAssetFallbackTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/HtmlOutputTemplateAssetFallbackTest.php
@@ -22,6 +22,7 @@ class HtmlOutputTemplateAssetFallbackTest extends zcUnitTestCase
     public function setUp(): void
     {
         parent::setUp();
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
         require_once DIR_FS_CATALOG . 'includes/functions/html_output.php';
 

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/PageLoaderTemplateResolutionTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/PageLoaderTemplateResolutionTest.php
@@ -6,11 +6,11 @@
 
 namespace Tests\Unit\testsTemplateResolver;
 
-use Tests\Support\zcUnitTestCase;
+use Tests\Support\zcTemplateResolverTest;
 use Zencart\FileSystem\FileSystem;
 use Zencart\PageLoader\PageLoader;
 
-class PageLoaderTemplateResolutionTest extends zcUnitTestCase
+class PageLoaderTemplateResolutionTest extends zcTemplateResolverTest
 {
     private const BASE_THEME_PLUGIN = 'UnitTestPageLoaderBaseTheme';
     private const CHILD_THEME_PLUGIN = 'UnitTestPageLoaderChildTheme';
@@ -28,7 +28,9 @@ class PageLoaderTemplateResolutionTest extends zcUnitTestCase
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/FileSystem.php';
         require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateSelect.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         require_once DIR_FS_CATALOG . 'includes/classes/traits/Singleton.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/PageLoader.php';
 
@@ -122,6 +124,12 @@ PHP
             '/* overlay */'
         );
         file_put_contents($this->baseThemeCssFixture, '/* base */');
+        $this->instantiateQfr([
+            'template_id' => '1',
+            'template_dir' => self::BASE_THEME_PLUGIN,
+            'template_language' => 0,
+            'template_settings' => null,
+        ]);
     }
 
     public function tearDown(): void

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/PageLoaderTemplateResolutionTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/PageLoaderTemplateResolutionTest.php
@@ -27,6 +27,7 @@ class PageLoaderTemplateResolutionTest extends zcUnitTestCase
     {
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/FileSystem.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
         require_once DIR_FS_CATALOG . 'includes/classes/traits/Singleton.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/PageLoader.php';

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/SideboxFinderTemplateResolutionTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/SideboxFinderTemplateResolutionTest.php
@@ -6,12 +6,12 @@
 
 namespace Tests\Unit\testsTemplateResolver;
 
-use Tests\Support\zcUnitTestCase;
+use Tests\Support\zcTemplateResolverTest;
 use Zencart\FileSystem\FileSystem;
 use Zencart\ResourceLoaders\SideboxFinder;
 use Zencart\ResourceLoaders\TemplateResolver;
 
-class SideboxFinderTemplateResolutionTest extends zcUnitTestCase
+class SideboxFinderTemplateResolutionTest extends zcTemplateResolverTest
 {
     private string $fixtureRoot;
 
@@ -20,7 +20,9 @@ class SideboxFinderTemplateResolutionTest extends zcUnitTestCase
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/FileSystem.php';
         require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateSelect.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/SideboxFinder.php';
 
         $this->fixtureRoot = sys_get_temp_dir() . '/zencart-sidebox-finder-' . uniqid('', true);
@@ -54,6 +56,13 @@ PHP
         file_put_contents($this->fixtureRoot . '/includes/modules/sideboxes/template_default/base_box.php', "<?php\n");
         file_put_contents($this->fixtureRoot . '/includes/modules/sideboxes/responsive_classic/base_override_box.php', "<?php\n");
         file_put_contents($this->fixtureRoot . '/zc_plugins/ChildTheme/v1.0.0/catalog/includes/modules/sideboxes/child_theme/child_box.php', "<?php\n");
+
+        $this->instantiateQfr([
+            'template_id' => '1',
+            'template_dir' => 'child_theme',
+            'template_language' => 0,
+            'template_settings' => null,
+        ]);
     }
 
     public function tearDown(): void

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/SideboxFinderTemplateResolutionTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/SideboxFinderTemplateResolutionTest.php
@@ -19,6 +19,7 @@ class SideboxFinderTemplateResolutionTest extends zcUnitTestCase
     {
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/FileSystem.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/SideboxFinder.php';
 

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/TemplateResolverTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/TemplateResolverTest.php
@@ -6,10 +6,10 @@
 
 namespace Tests\Unit\testsTemplateResolver;
 
-use Tests\Support\zcUnitTestCase;
+use Tests\Support\zcTemplateResolverTest;
 use Zencart\ResourceLoaders\TemplateResolver;
 
-class TemplateResolverTest extends zcUnitTestCase
+class TemplateResolverTest extends zcTemplateResolverTest
 {
     private string $fixtureRoot;
 
@@ -17,7 +17,9 @@ class TemplateResolverTest extends zcUnitTestCase
     {
         parent::setUp();
         require_once DIR_FS_CATALOG . 'includes/classes/TemplateDto.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/TemplateSelect.php';
         require_once DIR_FS_CATALOG . 'includes/classes/ResourceLoaders/TemplateResolver.php';
+        require_once DIR_FS_CATALOG . 'includes/classes/db/mysql/query_factory.php';
         $this->fixtureRoot = sys_get_temp_dir() . '/zencart-template-resolver-' . uniqid('', true);
         mkdir($this->fixtureRoot . '/includes/templates/template_default', 0777, true);
         mkdir($this->fixtureRoot . '/includes/templates/responsive_classic', 0777, true);
@@ -51,6 +53,12 @@ return [
 ];
 PHP
         );
+        $this->instantiateQfr([
+            'template_id' => '1',
+            'template_dir' => 'child_theme',
+            'template_language' => 0,
+            'template_settings' => null,
+        ]);
     }
 
     public function tearDown(): void


### PR DESCRIPTION
Any plugin version is used **only if** the base page doesn't provide one!

Noting that this change is needed to encapsulate One-Page Checkout.